### PR TITLE
feat:Add tty to prevent auto stop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,12 @@
 version: "3"
 services:
   arch-linux-vnc:
+    tty: true
     image: terwer/arch-linux-vnc:latest
     container_name: arch-linux-vnc
     build:
       context: ./arch-linux-vnc
-      dockerfile: ./arch-linux-vnc/Dockerfile
+      dockerfile: Dockerfile
     ports:
       - "5901:5901"
     restart: always


### PR DESCRIPTION
Since by default, docker-compose will auto stop the container after it runs.

We need to add `tty` with `true` in docker-compose.yml  to prevent auto stop.like this:

```
version: "3"
services:
  arch-linux-vnc:
    tty: true
```